### PR TITLE
Silence yfinance auto_adjust warnings

### DIFF
--- a/learn_core.py
+++ b/learn_core.py
@@ -57,7 +57,13 @@ def fetch_all_tickers():
 
 def process_ticker(ticker):
     try:
-        df = yf.download(ticker, period="30d", interval="1d", progress=False)
+        df = yf.download(
+            ticker,
+            period="30d",
+            interval="1d",
+            progress=False,
+            auto_adjust=True,
+        )
         if df.empty:
             return None
 


### PR DESCRIPTION
## Summary
- explicitly set `auto_adjust=True` when downloading data in `learn_core.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8cb4ebc48321b8a272646748f5e0