### PR TITLE
Fix fallback ticker logging emoji

### DIFF
--- a/learn_core.py
+++ b/learn_core.py
@@ -36,7 +36,7 @@ MACRO_FEATURES = fetch_macro_features()
 
 def fallback_tickers():
     """Return a static list of tickers if NASDAQ fetch fails."""
-    print("\ud83d\udcc4 Using local backup ticker list...")
+    print("📄 Using local backup ticker list...")
     return [
         "GFAI",
         "SNTI",


### PR DESCRIPTION
## Summary
- replace surrogate Unicode escape sequences with actual emoji in `fallback_tickers`

## Testing
- `python -m unittest discover -s tests -v`
- manual check `learn_core.fallback_tickers()`

------
https://chatgpt.com/codex/tasks/task_e_686da4adb93883218869c8e21b67d8ca