### PR TITLE
Add sequential pipeline run

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ def log(msg):
         f.write(full + "\n")
 
 def learn():
+    """Train models and generate the penny watchlist."""
     log("🧠 Running learn_core.py...")
     subprocess.call(["python3", "learn_core.py"])
 
@@ -56,8 +57,20 @@ def run_options_update():
     log("🎯 Running options_ai.py updates...")
     subprocess.call(["python3", "options_ai.py"])
 
-log("✅ Scheduler started")
-learn()
+
+def run_sequence():
+    """Run core modules once in a logical order."""
+    learn()
+    run_penny()
+    predict()
+    run_options_update()
+    grade()
+    evolve()
+    report()
+    execute_trades()
+    repair()
+
+
 
 schedule.every(10).minutes.do(learn)
 schedule.every().hour.do(repair)
@@ -80,12 +93,10 @@ schedule.every().day.at("09:35").do(lambda: subprocess.call(["python3", "penny_a
 schedule.every().day.at("16:15").do(lambda: subprocess.call(["python3", "learn_core.py"]))
 schedule.every().day.at("17:00").do(lambda: subprocess.call(["python3", "email_reporter.py"]))
 
-while True:
-    schedule.run_pending()
-    time.sleep(10)
-
 if __name__ == "__main__":
-    learn()
+    run_sequence()
+    log("🔄 Entering scheduler loop")
     schedule.run_pending()
     while True:
+        schedule.run_pending()
         time.sleep(10)

--- a/penny_ai.py
+++ b/penny_ai.py
@@ -4,7 +4,13 @@ import os
 import requests
 import pandas as pd
 
-tickers = ["GFAI", "MULN", "SOUN"]  # Delisted ones removed
+WATCHLIST_FILE = "../logs/penny_watchlist.txt"
+if os.path.exists(WATCHLIST_FILE):
+    with open(WATCHLIST_FILE) as f:
+        tickers = [line.strip() for line in f if line.strip()]
+else:
+    tickers = ["GFAI", "MULN", "SOUN"]  # default tickers
+
 high_short_interest = {"GFAI": 0.25, "MULN": 0.30, "SOUN": 0.28}
 log_file = "../logs/penny_trades.log"
 os.makedirs("../logs", exist_ok=True)


### PR DESCRIPTION
## Summary
- create a `run_sequence` helper in `main.py` to orchestrate the full pipeline
- trim the global scheduler loop and run scheduling only in `__main__`
- document `learn()` purpose

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_686daf9f5eec83218932af017d977507