### PR TITLE
Fix deprecated datetime.utcnow usage

### DIFF
--- a/ai_modules/ai_stop_loss_manager.py
+++ b/ai_modules/ai_stop_loss_manager.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import random
 
 
@@ -8,14 +8,14 @@ def trailing_stop(entry_price: float, atr: float) -> float:
 
 
 def time_stop(entry_time: datetime, max_hours: int = 4) -> bool:
-    return datetime.utcnow() - entry_time > timedelta(hours=max_hours)
+    return datetime.now(timezone.utc) - entry_time > timedelta(hours=max_hours)
 
 
 def example_usage():
     price = 100.0
     atr = random.uniform(1, 3)
     ts = trailing_stop(price, atr)
-    exit_now = time_stop(datetime.utcnow() - timedelta(hours=5))
+    exit_now = time_stop(datetime.now(timezone.utc) - timedelta(hours=5))
     print(f"ATR {atr:.2f} -> trailing stop {ts}; time exit: {exit_now}")
 
 

--- a/ai_modules/alt_data_ingest.py
+++ b/ai_modules/alt_data_ingest.py
@@ -1,6 +1,6 @@
 import json
 import requests
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Placeholder API endpoints for various news and alternative data sources
 SOURCES = {
@@ -35,11 +35,11 @@ def parse_filings(text: str) -> list[str]:
 
 def collect_alt_data() -> dict:
     news = fetch_news()
-    payload = {"timestamp": datetime.utcnow().isoformat(), "news": news}
+    payload = {"timestamp": datetime.now(timezone.utc).isoformat(), "news": news}
     path = "../data/alt_data.json"
     with open(path, "w") as f:
         json.dump(payload, f)
-    print(f"[{datetime.utcnow()}] 📵 Alt data saved -> {path}")
+    print(f"[{datetime.now(timezone.utc)}] 📵 Alt data saved -> {path}")
     return payload
 
 

--- a/ai_modules/dark_pool_flow.py
+++ b/ai_modules/dark_pool_flow.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def fetch_dark_pool_volume(ticker: str) -> float:
@@ -26,7 +26,7 @@ def flag_unusual_activity(tickers: list[str]) -> list[str]:
         if dark_vol > 500_000 or oi > 50_000 or pcr > 1.5:
             flagged.append(t)
     if flagged:
-        print(f"[{datetime.utcnow()}] \U0001f50e Unusual flow: {', '.join(flagged)}")
+        print(f"[{datetime.now(timezone.utc)}] \U0001f50e Unusual flow: {', '.join(flagged)}")
     return flagged
 
 

--- a/ai_modules/flow_analysis_ai.py
+++ b/ai_modules/flow_analysis_ai.py
@@ -1,7 +1,7 @@
 import random
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 TICKERS = sys.argv[1:] or ["AAPL", "TSLA"]
 
@@ -16,7 +16,7 @@ def main():
     path = "../data/flow_scores.json"
     with open(path, "w") as f:
         json.dump(scores, f)
-    print(f"[{datetime.utcnow()}] 💰 Flow scores saved -> {path}")
+    print(f"[{datetime.now(timezone.utc)}] 💰 Flow scores saved -> {path}")
 
 
 def load_flow_scores() -> dict:

--- a/ai_modules/macro_trend_ai.py
+++ b/ai_modules/macro_trend_ai.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 REGIMES = ["BULL", "BEAR", "CHOP"]
 
@@ -12,7 +12,7 @@ def main():
     regime = detect_regime()
     with open("../data/macro_regime.txt", "w") as f:
         f.write(regime)
-    print(f"[{datetime.utcnow()}] 🌎 Market regime -> {regime}")
+    print(f"[{datetime.now(timezone.utc)}] 🌎 Market regime -> {regime}")
 
 
 def current_regime() -> str:

--- a/ai_modules/news_sentiment_ai.py
+++ b/ai_modules/news_sentiment_ai.py
@@ -1,7 +1,7 @@
 import random
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 TICKERS = sys.argv[1:] or ["AAPL", "TSLA", "SPY"]
 
@@ -16,7 +16,7 @@ def main():
     path = "../data/news_sentiment.json"
     with open(path, "w") as f:
         json.dump(scores, f)
-    print(f"[{datetime.utcnow()}] 📰 Sentiment scores saved -> {path}")
+    print(f"[{datetime.now(timezone.utc)}] 📰 Sentiment scores saved -> {path}")
 
 
 def load_scores() -> dict:

--- a/ai_modules/social_alpha.py
+++ b/ai_modules/social_alpha.py
@@ -1,7 +1,7 @@
 import json
 import re
 import requests
-from datetime import datetime
+from datetime import datetime, timezone
 
 HEADERS = {"User-Agent": "superbot"}
 
@@ -45,8 +45,8 @@ def aggregate_trending() -> list[tuple[str, int]]:
     trending = sorted(counts.items(), key=lambda x: x[1], reverse=True)[:5]
     path = "../data/social_alpha.json"
     with open(path, "w") as f:
-        json.dump({"timestamp": datetime.utcnow().isoformat(), "trending": trending}, f)
-    print(f"[{datetime.utcnow()}] \U0001F4AC Social alpha saved -> {path}")
+        json.dump({"timestamp": datetime.now(timezone.utc).isoformat(), "trending": trending}, f)
+    print(f"[{datetime.now(timezone.utc)}] \U0001F4AC Social alpha saved -> {path}")
     return trending
 
 

--- a/ai_modules/volatility_predictor_ai.py
+++ b/ai_modules/volatility_predictor_ai.py
@@ -1,7 +1,7 @@
 import random
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 TICKERS = sys.argv[1:] or ["AAPL"]
 
@@ -16,7 +16,7 @@ def main():
     path = "../data/volatility.json"
     with open(path, "w") as f:
         json.dump(preds, f)
-    print(f"[{datetime.utcnow()}] ⚡ Volatility predictions saved -> {path}")
+    print(f"[{datetime.now(timezone.utc)}] ⚡ Volatility predictions saved -> {path}")
 
 
 def load_predictions() -> dict:

--- a/auto_debugger.py
+++ b/auto_debugger.py
@@ -1,6 +1,6 @@
 import os
 import traceback
-import datetime
+from datetime import datetime, timezone
 
 STRATEGY_DIR = "../strategy"
 LOG_FILE = "../logs/self_fixes.log"
@@ -24,13 +24,13 @@ def fix_file(path, error_msg):
         if "==" in lines[i] or "return" in lines[i] or "=" in lines[i]:
             lines[i] = "# 🧠 auto-fixed: " + lines[i]
 
-    lines.insert(0, "# 🧠 Auto-debugger modified this file on " + datetime.datetime.utcnow().isoformat() + "\n")
+    lines.insert(0, "# 🧠 Auto-debugger modified this file on " + datetime.now(timezone.utc).isoformat() + "\n")
 
     with open(path, "w") as f:
         f.writelines(lines)
 
     with open(LOG_FILE, "a") as log:
-        log.write(f"[{datetime.datetime.utcnow()}] 🔧 Fixed {path} with msg: {error_msg}\n")
+        log.write(f"[{datetime.now(timezone.utc)}] 🔧 Fixed {path} with msg: {error_msg}\n")
 
 def main():
     for file in os.listdir(STRATEGY_DIR):

--- a/email_reporter.py
+++ b/email_reporter.py
@@ -1,5 +1,5 @@
 import smtplib, os
-from datetime import datetime
+from datetime import datetime, timezone
 from email.mime.text import MIMEText
 
 EMAIL_FROM = os.getenv("EMAIL_FROM")
@@ -41,7 +41,7 @@ def penny_summary(path):
 
 # Report summary
 summary = f"""
-📊 Superbot AI Status – {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC
+📊 Superbot AI Status – {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} UTC
 
 ✅ Models trained: {len(os.listdir('../models'))}
 📂 Logs recorded: {len(os.listdir('../logs'))}

--- a/execution/trade_logger.py
+++ b/execution/trade_logger.py
@@ -1,6 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def log_trade(msg: str, path: str = "../logs/trades.log"):
     with open(path, "a") as f:
-        f.write(f"[{datetime.utcnow()}] {msg}\n")
+        f.write(f"[{datetime.now(timezone.utc)}] {msg}\n")

--- a/ibkr_executor_sim.py
+++ b/ibkr_executor_sim.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import random
 from ai_modules.ai_stop_loss_manager import trailing_stop
 from execution.position_sizer import size_position
@@ -36,16 +36,16 @@ mock_signals = [
 ]
 
 broker = choose_broker()
-print(f"[{datetime.utcnow()}] Using broker {broker}")
+print(f"[{datetime.now(timezone.utc)}] Using broker {broker}")
 flagged = check_anomalies([s["ticker"] for s in mock_signals])
 
 with open(log_file, "a") as f:
     for signal in mock_signals:
         if signal["ticker"] in flagged:
-            print(f"[{datetime.utcnow()}] ⚠️ {signal['ticker']} suspended due to anomaly")
+            print(f"[{datetime.now(timezone.utc)}] ⚠️ {signal['ticker']} suspended due to anomaly")
             continue
         if open_positions >= max_positions:
-            print(f"[{datetime.utcnow()}] 🚫 Max positions reached. Skipping {signal['ticker']}")
+            print(f"[{datetime.now(timezone.utc)}] 🚫 Max positions reached. Skipping {signal['ticker']}")
             continue
         price = signal.get("price", signal.get("premium", 0))
         qty = signal.get("qty", 1)
@@ -54,7 +54,7 @@ with open(log_file, "a") as f:
         cost = min(price * qty, size)
 
         if used_margin + abs(cost) > margin_limit:
-            print(f"[{datetime.utcnow()}] ⚠️ Margin limit reached. Skipping {signal['ticker']}")
+            print(f"[{datetime.now(timezone.utc)}] ⚠️ Margin limit reached. Skipping {signal['ticker']}")
             continue
 
         executed_price = place_order(signal, size)
@@ -69,7 +69,7 @@ with open(log_file, "a") as f:
         open_positions += 1
 
         msg = (
-            f"[{datetime.utcnow()}] 💡 Simulated trade: {signal['action']} on {signal['ticker']} | "
+            f"[{datetime.now(timezone.utc)}] 💡 Simulated trade: {signal['action']} on {signal['ticker']} | "
             f"Strategy: {signal['strategy']} | Filled at: ${executed_price} | PnL: {round(pnl,2)} | Stop: {stop}"
         )
         print(msg)
@@ -80,7 +80,7 @@ with open(log_file, "a") as f:
                 pf.write(f"{signal['ticker']},{signal.get('price')},{exit_price},{signal['strategy']},{round((pnl / (signal.get('price') * signal.get('qty',1))) * 100,2) if exit_price else ''}\n")
 
         if daily_pnl < max_drawdown:
-            print(f"[{datetime.utcnow()}] 🛑 Max drawdown reached. Halting trades.")
+            print(f"[{datetime.now(timezone.utc)}] 🛑 Max drawdown reached. Halting trades.")
             break
 
 if __name__ == "__main__":

--- a/learn_core.py
+++ b/learn_core.py
@@ -1,6 +1,6 @@
 import yfinance as yf
 import pandas as pd
-from datetime import datetime
+from datetime import datetime, timezone
 import pickle
 import os
 import requests
@@ -58,7 +58,7 @@ def fallback_tickers():
 
 def fetch_from_nasdaq():
     """Fetch the current NASDAQ listed tickers."""
-    print(f"[{datetime.utcnow()}] \U0001f310 Fetching tickers from NASDAQ Trader...")
+    print(f"[{datetime.now(timezone.utc)}] \U0001f310 Fetching tickers from NASDAQ Trader...")
     url = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"
     df = pd.read_csv(StringIO(requests.get(url, timeout=10).text), sep="|")
     tickers = df["Symbol"].dropna().tolist()
@@ -126,7 +126,7 @@ def process_ticker_data(ticker, df):
 
     model = {
         "ticker": ticker,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "avg_return": avg_return,
         "volatility": volatility,
         "is_penny": is_penny,
@@ -138,11 +138,11 @@ def process_ticker_data(ticker, df):
         "macro": macro,
     }
 
-    with open(f"{MODEL_DIR}/{ticker}_{datetime.utcnow().date()}.pkl", "wb") as f:
+    with open(f"{MODEL_DIR}/{ticker}_{datetime.now(timezone.utc).date()}.pkl", "wb") as f:
         pickle.dump(model, f)
 
     tag = "🪙 PENNY" if is_penny else "💼"
-    print(f"[{datetime.utcnow()}] ✅ {ticker} model saved. {tag}")
+    print(f"[{datetime.now(timezone.utc)}] ✅ {ticker} model saved. {tag}")
     return ticker
 
 
@@ -158,7 +158,7 @@ def process_ticker(ticker):
         )
         return process_ticker_data(ticker, df)
     except Exception as e:
-        print(f"[{datetime.utcnow()}] ❌ {ticker} failed: {e}")
+        print(f"[{datetime.now(timezone.utc)}] ❌ {ticker} failed: {e}")
         return None
 
 def walk_forward_optimization(model):
@@ -180,7 +180,7 @@ def analyze_penny_trades(log_path="../logs/penny_trade_log.csv"):
     best = summary.sort_values("avg_pct", ascending=False).head(3)
     best_str = "; ".join(f"{row.Ticker}:{round(row.avg_pct,2)}%" for _, row in best.iterrows())
     with open("../logs/learn.log", "a") as f:
-        f.write(f"[{datetime.utcnow()}] 📊 Penny trade analysis: {best_str}\n")
+        f.write(f"[{datetime.now(timezone.utc)}] 📊 Penny trade analysis: {best_str}\n")
     return summary
 
 # --- Fast multithreaded scanning utilities ---
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     if len(tickers) > MAX_TICKERS:
         tickers = random.sample(tickers, MAX_TICKERS)
     print(
-        f"[{datetime.utcnow()}] 🚀 Starting fast scan of {len(tickers)} tickers using thread pool..."
+        f"[{datetime.now(timezone.utc)}] 🚀 Starting fast scan of {len(tickers)} tickers using thread pool..."
     )
 
     batches = list(chunk(tickers, 100))

--- a/main.py
+++ b/main.py
@@ -2,14 +2,14 @@ import schedule
 import time
 import subprocess
 import os
-from datetime import datetime, timedelta, time as dt_time
+from datetime import datetime, timedelta, time as dt_time, timezone
 
 log_dir = "../logs"
 os.makedirs(log_dir, exist_ok=True)
 log_file = os.path.join(log_dir, "learn.log")
 
 def log(msg):
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     full = f"[{timestamp}] {msg}"
     print(full)
     with open(log_file, "a") as f:
@@ -47,7 +47,7 @@ def execute_trades():
     subprocess.call(["python3", "ibkr_executor_sim.py"])
 
 def in_market_hours():
-    now = datetime.utcnow() - timedelta(hours=4)
+    now = datetime.now(timezone.utc) - timedelta(hours=4)
     return dt_time(9, 30) <= now.time() <= dt_time(16, 0)
 
 def run_penny():

--- a/market_anomaly_detector.py
+++ b/market_anomaly_detector.py
@@ -1,6 +1,6 @@
 import random
 import requests
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def is_ticker_halted(ticker: str) -> bool:
@@ -27,7 +27,7 @@ def check_anomalies(tickers: list[str]) -> list[str]:
         if is_ticker_halted(t) or flash_crash_detected(t):
             flagged.append(t)
     if flagged:
-        print(f"[{datetime.utcnow()}] \U0001f6a8 Market anomaly detected: {', '.join(flagged)}")
+        print(f"[{datetime.now(timezone.utc)}] \U0001f6a8 Market anomaly detected: {', '.join(flagged)}")
     return flagged
 
 

--- a/module_runner.py
+++ b/module_runner.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 
 STRATEGY_DIR = "../strategy"
 LOG_FILE = "../logs/module_runner.log"
@@ -10,7 +10,7 @@ os.makedirs("../logs", exist_ok=True)
 
 def log(msg):
     with open(LOG_FILE, "a") as f:
-        entry = f"[{datetime.utcnow().isoformat()}] {msg}\n"
+        entry = f"[{datetime.now(timezone.utc).isoformat()}] {msg}\n"
         print(entry.strip())
         f.write(entry)
 

--- a/news_trade_generator.py
+++ b/news_trade_generator.py
@@ -1,5 +1,5 @@
 from ai_modules.news_sentiment_ai import load_scores
-from datetime import datetime
+from datetime import datetime, timezone
 
 KEYWORDS = ["Acquisition", "FDA Approval"]
 
@@ -8,7 +8,7 @@ def generate_trades():
     scores = load_scores()
     for ticker, score in scores.items():
         if score > 0.5:
-            print(f"[{datetime.utcnow()}] 📢 News trade: Buying {ticker} on positive news")
+            print(f"[{datetime.now(timezone.utc)}] 📢 News trade: Buying {ticker} on positive news")
 
 
 if __name__ == "__main__":

--- a/options_ai.py
+++ b/options_ai.py
@@ -2,7 +2,7 @@ import os
 import pickle
 from ai_modules.flow_analysis_ai import load_flow_scores
 from ai_modules.volatility_predictor_ai import load_predictions
-from datetime import datetime
+from datetime import datetime, timezone
 import yfinance as yf
 import requests
 
@@ -38,7 +38,7 @@ def sentiment(ticker):
         pass
     return 0.0
 
-print(f"[{datetime.utcnow()}] 📊 Checking model scores...")
+print(f"[{datetime.now(timezone.utc)}] 📊 Checking model scores...")
 
 with open(log_file, "a") as log:
     for file in os.listdir(model_dir):
@@ -55,7 +55,7 @@ with open(log_file, "a") as log:
                 if score + flow + short_int > 0.5 and vol_pred < 0.08 and filter_candidate(model["ticker"]):
                     if sentiment(model["ticker"]) > 0.05:
                         msg = (
-                            f"[{datetime.utcnow()}] 📈 Consider selling CSP on {model['ticker']} | "
+                            f"[{datetime.now(timezone.utc)}] 📈 Consider selling CSP on {model['ticker']} | "
                             f"Alpha Score: {round(score, 3)} | Flow: {round(flow,2)} | Short: {short_int} | IVpred: {round(vol_pred,3)}\n"
                         )
                         log.write(msg)

--- a/penny_ai.py
+++ b/penny_ai.py
@@ -1,5 +1,5 @@
 import yfinance as yf
-from datetime import datetime, time as dt_time
+from datetime import datetime, time as dt_time, timezone
 import os
 import requests
 import pandas as pd
@@ -81,13 +81,13 @@ with open(log_file, "a") as log:
                 if gap > 0.05 or short_int > 0.25 or sent > 0.05:
                     if check_entry(df):
                         msg = (
-                            f"[{datetime.utcnow()}] 🚀 {ticker} breakout! "
+                            f"[{datetime.now(timezone.utc)}] 🚀 {ticker} breakout! "
                             f"Volume: {round(vol_score, 1)}x | Move: +{round(price_jump * 100, 2)}%\n"
                         )
                         print(msg.strip())
                         log.write(msg)
         except Exception as e:
-            print(f"[{datetime.utcnow()}] ⚠️ {ticker} failed: {e}")
+            print(f"[{datetime.now(timezone.utc)}] ⚠️ {ticker} failed: {e}")
 
 
 if __name__ == "__main__":

--- a/penny_risk_ai.py
+++ b/penny_risk_ai.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import pandas as pd
 
 
@@ -25,4 +25,4 @@ def manage_trade(df, entry_price):
     }
 
 if __name__ == '__main__':
-    print(f"[{datetime.utcnow()}] Penny risk manager ready.")
+    print(f"[{datetime.now(timezone.utc)}] Penny risk manager ready.")

--- a/penny_scanner_ai.py
+++ b/penny_scanner_ai.py
@@ -1,7 +1,7 @@
 import yfinance as yf
 import pandas as pd
 import requests
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 
@@ -76,7 +76,7 @@ for ticker in TICKERS:
             'score': score
         })
     except Exception as e:
-        print(f"[{datetime.utcnow()}] ❌ {ticker} scan failed: {e}")
+        print(f"[{datetime.now(timezone.utc)}] ❌ {ticker} scan failed: {e}")
 
 results.sort(key=lambda x: x['score'], reverse=True)
 print(json.dumps(results, indent=2))

--- a/predict_core.py
+++ b/predict_core.py
@@ -1,6 +1,6 @@
 # predict_core.py — placeholder for prediction logic
 
-from datetime import datetime
+from datetime import datetime, timezone
 import random
 from ai_modules.news_sentiment_ai import load_scores
 from ai_modules.multi_model_ensemble import weighted_ensemble_predict
@@ -8,7 +8,7 @@ from ai_modules.macro_trend_ai import current_regime
 
 def predict():
     regime = current_regime()
-    print(f"[{datetime.utcnow()}] Market regime: {regime}")
+    print(f"[{datetime.now(timezone.utc)}] Market regime: {regime}")
     gap_signal = random.random() > 0.8
     mean_revert_signal = random.random() > 0.7
     vote, confidence = weighted_ensemble_predict(regime=regime)
@@ -17,18 +17,18 @@ def predict():
     avoid_trade = any(v < -0.5 for v in sentiment.values())
 
     if gap_signal:
-        print(f"[{datetime.utcnow()}] 📈 Gap-and-Go signal detected")
+        print(f"[{datetime.now(timezone.utc)}] 📈 Gap-and-Go signal detected")
     if mean_revert_signal:
-        print(f"[{datetime.utcnow()}] 🔻 Mean reversion short signal")
+        print(f"[{datetime.now(timezone.utc)}] 🔻 Mean reversion short signal")
     if vote:
-        print(f"[{datetime.utcnow()}] 🧠 Ensemble vote suggests entry; confidence {confidence:.2f}")
+        print(f"[{datetime.now(timezone.utc)}] 🧠 Ensemble vote suggests entry; confidence {confidence:.2f}")
     if confidence < 0.7:
-        print(f"[{datetime.utcnow()}] ⚠️ Low confidence {confidence:.2f}. Skipping trade")
+        print(f"[{datetime.now(timezone.utc)}] ⚠️ Low confidence {confidence:.2f}. Skipping trade")
         return
     if avoid_trade:
-        print(f"[{datetime.utcnow()}] 🚩 Negative news detected. Avoiding trades")
+        print(f"[{datetime.now(timezone.utc)}] 🚩 Negative news detected. Avoiding trades")
     if not any([gap_signal, mean_revert_signal, vote]) or avoid_trade:
-        print(f"[{datetime.utcnow()}] 🔮 Running basic prediction logic...")
+        print(f"[{datetime.now(timezone.utc)}] 🔮 Running basic prediction logic...")
 
 if __name__ == "__main__":
     predict()

--- a/retrain_scheduler.py
+++ b/retrain_scheduler.py
@@ -1,16 +1,16 @@
 import os
 import random
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def main():
     underperform = random.random() < 0.5
     if underperform:
-        print(f"[{datetime.utcnow()}] 🔄 Retraining models...")
+        print(f"[{datetime.now(timezone.utc)}] 🔄 Retraining models...")
         subprocess.call(["python3", "learn_core.py"])
     else:
-        print(f"[{datetime.utcnow()}] ✅ Models performing well. No retrain.")
+        print(f"[{datetime.now(timezone.utc)}] ✅ Models performing well. No retrain.")
 
 
 if __name__ == "__main__":

--- a/self_runner.py
+++ b/self_runner.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import datetime
+from datetime import datetime, timezone
 
 STRATEGY_DIR = "../strategy"
 LOG_FILE = "../logs/error_map.log"
@@ -14,7 +14,7 @@ for file in os.listdir(STRATEGY_DIR):
             subprocess.check_output(["python3", path], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             with open(LOG_FILE, "a") as log:
-                log.write(f"[{datetime.datetime.utcnow()}] ❌ {file} failed:\n{e.output.decode()}\n")
+                log.write(f"[{datetime.now(timezone.utc)}] ❌ {file} failed:\n{e.output.decode()}\n")
             print(f"❌ {file} failed — sending to auto_debugger")
             subprocess.call(["python3", "auto_debugger.py"])
 

--- a/strategy_engine/self_optimizer_ai.py
+++ b/strategy_engine/self_optimizer_ai.py
@@ -1,6 +1,6 @@
 import random
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from strategy_writer import generate_strategy
 
 STRATEGY_DIR = "../strategy"
@@ -16,7 +16,7 @@ def mutate_strategy(name: str):
 def main():
     for i in range(5):
         mutate_strategy(f"ga_{i}_{int(random.random()*1000)}")
-    print(f"[{datetime.utcnow()}] 🤖 Strategies mutated.")
+    print(f"[{datetime.now(timezone.utc)}] 🤖 Strategies mutated.")
 
 
 if __name__ == "__main__":

--- a/strategy_engine/superbacktester.py
+++ b/strategy_engine/superbacktester.py
@@ -2,7 +2,7 @@ import os
 import importlib.util
 import shutil
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 STRATEGY_DIR = "../strategy"
 LIVE_DIR = "../live_strategies"
@@ -30,7 +30,7 @@ def main():
     log_file = "../logs/strategy_performance.log"
     with open(log_file, "a") as log:
         for score, file in results:
-            log.write(f"[{datetime.utcnow()}] {file} score: {round(score,3)}\n")
+            log.write(f"[{datetime.now(timezone.utc)}] {file} score: {round(score,3)}\n")
 
     # Prune bottom 20% from strategy directory
     if results:
@@ -47,7 +47,7 @@ def main():
     for _, file in results[:5]:
         shutil.copy(os.path.join(STRATEGY_DIR, file), os.path.join(LIVE_DIR, file))
 
-    print(f"[{datetime.utcnow()}] ⏪ Backtest complete. Top strategies updated.")
+    print(f"[{datetime.now(timezone.utc)}] ⏪ Backtest complete. Top strategies updated.")
 
 
 if __name__ == "__main__":

--- a/strategy_grader.py
+++ b/strategy_grader.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 grades_log = "../logs/strategy_grades.log"
 results_dir = "../logs/results"
@@ -24,6 +24,6 @@ with open(grades_log, "a") as log:
         if file.endswith(".txt"):
             avg_roi, win_rate = evaluate(file)
             status = "✅ PROMOTE" if avg_roi > 0.01 and win_rate > 0.6 else "❌ DEMOTE"
-            msg = f"[{datetime.utcnow()}] {file}: ROI={avg_roi}, WinRate={win_rate} → {status}"
+            msg = f"[{datetime.now(timezone.utc)}] {file}: ROI={avg_roi}, WinRate={win_rate} → {status}"
             print(msg)
             log.write(msg + "\n")

--- a/strategy_writer.py
+++ b/strategy_writer.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import random
 
 STRATEGY_DIR = "../strategy"
@@ -22,16 +22,16 @@ def generate_strategy(name):
     code = f"""
 # Auto-generated strategy: {name}
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 def run():
     score = random.uniform(0.1, 0.8)
-    print(f"[{{datetime.utcnow()}}] 🚀 {name} ({template}): mock alpha score = {{round(score, 3)}}")
+    print(f"[{{datetime.now(timezone.utc)}}] 🚀 {name} ({template}): mock alpha score = {{round(score, 3)}}")
     return score
 """
     return code
 
-timestamp = datetime.utcnow().strftime("%H%M%S")
+timestamp = datetime.now(timezone.utc).strftime("%H%M%S")
 strat_name = f"alpha_{timestamp}"
 file_name = os.path.join(STRATEGY_DIR, f"{strat_name}.py")
 
@@ -39,12 +39,12 @@ with open(file_name, "w") as f:
     f.write(generate_strategy(strat_name))
 
 with open(LOG_FILE, "a") as log:
-    log.write(f"[{datetime.utcnow()}] 🧠 Created new strategy: {strat_name}.py\n")
+    log.write(f"[{datetime.now(timezone.utc)}] 🧠 Created new strategy: {strat_name}.py\n")
 
 print(f"✅ New strategy written: {strat_name}.py")
 
 if __name__ == "__main__":
-    timestamp = datetime.utcnow().strftime("%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%H%M%S")
     strat_name = f"alpha_{timestamp}"
     file_name = os.path.join("../strategy", f"{strat_name}.py")
     with open(file_name, "w") as f:

--- a/trade_journal.py
+++ b/trade_journal.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 JOURNAL_PATH = "../logs/trade_journal.md"
@@ -10,7 +10,7 @@ def journal_trade(ticker, reason, pnl, confidence):
         f"  Reason: {reason}\n"
     )
     with open(JOURNAL_PATH, "a") as f:
-        f.write(f"[{datetime.utcnow()}] \n{entry}\n")
+        f.write(f"[{datetime.now(timezone.utc)}] \n{entry}\n")
 
 if __name__ == "__main__":
     journal_trade("TSLA", "Oversold bounce", 50, 0.84)


### PR DESCRIPTION
## Summary
- update all occurrences of `datetime.utcnow()` to `datetime.now(timezone.utc)`
- import `timezone` throughout the codebase

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc6d9428c832186dffd0b5b4d1a98