### PR TITLE
Add smart automation modules and cron setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 PYTHONPATH=.
+EMAIL_USER=you@example.com
+EMAIL_PASS=yourapppassword

--- a/async_scanner.py
+++ b/async_scanner.py
@@ -1,0 +1,18 @@
+import asyncio
+import aiohttp
+import nest_asyncio
+
+# Example list of tickers; populate with many more as needed
+TICKERS = ["AAPL", "TSLA", "SPY"]
+
+async def fetch(session, ticker):
+    async with session.get(f"https://finance.yahoo.com/quote/{ticker}") as resp:
+        await resp.text()
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        await asyncio.gather(*(fetch(session, t) for t in TICKERS))
+
+if __name__ == "__main__":
+    nest_asyncio.apply()
+    asyncio.run(main())

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,0 +1,1 @@
+0 6 * * * python3 smart_self_trainer.py && python3 roll_manager.py && python3 email_reporter.py

--- a/email_reporter.py
+++ b/email_reporter.py
@@ -1,3 +1,5 @@
+from dotenv import load_dotenv
+load_dotenv()
 import logging; logging.basicConfig(level=logging.INFO)
 import smtplib, os
 from datetime import datetime, timezone
@@ -7,8 +9,8 @@ EMAIL_FROM = os.getenv("EMAIL_FROM")
 EMAIL_TO = os.getenv("EMAIL_TO")
 SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
 SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
-SMTP_USER = os.getenv("SMTP_USER")
-SMTP_PASS = os.getenv("SMTP_PASS")
+SMTP_USER = os.getenv("EMAIL_USER", os.getenv("SMTP_USER"))
+SMTP_PASS = os.getenv("EMAIL_PASS", os.getenv("SMTP_PASS"))
 
 def last_trades(path, n=5):
     if not os.path.exists(path):

--- a/equity_plot.py
+++ b/equity_plot.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+DATA_PATH = "logs/trade_journal.csv"
+
+def plot_equity_curve():
+    df = pd.read_csv(DATA_PATH)
+    if "PnL" not in df.columns or "Date" not in df.columns:
+        print("Missing columns in trade journal")
+        return
+    df["cum_pnl"] = df["PnL"].cumsum()
+    plt.figure()
+    plt.plot(df["Date"], df["cum_pnl"])
+    plt.title("Equity Curve")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig("logs/equity_curve.png")
+
+if __name__ == "__main__":
+    plot_equity_curve()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+aiohttp
+nest_asyncio
+python-dotenv
+matplotlib
 schedule
 yfinance
 pandas

--- a/rl_tuner.py
+++ b/rl_tuner.py
@@ -1,0 +1,7 @@
+from stable_baselines3 import PPO
+
+
+def train(env):
+    model = PPO("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=10000)
+    model.save("rl_model")

--- a/roll_manager.py
+++ b/roll_manager.py
@@ -1,0 +1,6 @@
+def should_roll(position):
+    return position.days_to_expiry() < 3 or position.is_in_the_money()
+
+
+def roll(position):
+    print(f"Rolling {position.symbol} to next expiry...")

--- a/smart_filter.py
+++ b/smart_filter.py
@@ -1,0 +1,2 @@
+def is_trade_ok(macro, vix, news, conf):
+    return macro == "bullish" and vix < 20 and news > 0.5 and conf > 0.85

--- a/smart_self_trainer.py
+++ b/smart_self_trainer.py
@@ -1,0 +1,31 @@
+import os
+import pickle
+from datetime import datetime
+
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier
+
+DATA_PATH = "logs/trade_journal.csv"
+MODEL_DIR = "models"
+os.makedirs(MODEL_DIR, exist_ok=True)
+
+def train_from_history():
+    if not os.path.exists(DATA_PATH):
+        print("No trade history found")
+        return
+    df = pd.read_csv(DATA_PATH)
+    required = {"volume", "volatility", "rsi", "macd", "PnL"}
+    if not required.issubset(df.columns):
+        print("Trade history missing required columns")
+        return
+    df["label"] = df["PnL"].apply(lambda x: 1 if x > 0 else 0)
+    X = df[["volume", "volatility", "rsi", "macd"]]
+    y = df["label"]
+    model = GradientBoostingClassifier().fit(X, y)
+    fname = f"{MODEL_DIR}/self_trained_{datetime.utcnow().date()}.pkl"
+    with open(fname, "wb") as f:
+        pickle.dump(model, f)
+    print(f"Model saved to {fname}")
+
+if __name__ == "__main__":
+    train_from_history()

--- a/strategy_monitor.py
+++ b/strategy_monitor.py
@@ -1,0 +1,2 @@
+def evaluate(strategy_results):
+    return strategy_results.get('sharpe', 0) > 2.0 and strategy_results.get('win_rate', 0) > 0.6

--- a/trade_guard.py
+++ b/trade_guard.py
@@ -1,0 +1,2 @@
+def should_stop(loss_today):
+    return loss_today < -500

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -1,0 +1,6 @@
+def walk_forward(strategy_fn, data, window=60):
+    results = []
+    for i in range(len(data) - window):
+        slice_ = data[i : i + window]
+        results.append(strategy_fn(slice_))
+    return results


### PR DESCRIPTION
## Summary
- add self-training helper from trade history
- add async ticker scanner
- implement rolling manager utilities
- include walk-forward optimizer and RL tuner modules
- add smart filters, trade guard, and strategy monitor
- generate equity curve plot
- load email credentials using `python-dotenv`
- update requirements and provide sample cronjob

## Testing
- `pip install aiohttp nest_asyncio python-dotenv matplotlib >/tmp/pip.log`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_686e5fc1da3c8321b290579770fb8481