### PR TITLE
Improve regime detection and journaling

### DIFF
--- a/.github/workflows/bot-test.yml
+++ b/.github/workflows/bot-test.yml
@@ -1,0 +1,17 @@
+name: Bot Test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+    - name: Run tests
+      run: pytest tests/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This repository contains experimental trading bots and utilities.
 
 ## Running Tests
 
-Install dependencies and execute the unit tests using Python's built-in test runner:
+Install dependencies and execute the unit tests using pytest:
 
 ```bash
 pip install -r requirements.txt
-python -m unittest discover -s tests
+pytest tests/
 ```
 
 ## New Features

--- a/ai_modules/macro_trend_ai.py
+++ b/ai_modules/macro_trend_ai.py
@@ -1,15 +1,38 @@
 import random
 from datetime import datetime, timezone
+import os
 
-REGIMES = ["BULL", "BEAR", "CHOP"]
+import pandas as pd
+import yfinance as yf
+
+REGIMES = ["BULL", "BEAR", "CHOPPY"]
 
 
 def detect_regime() -> str:
-    return random.choice(REGIMES)
+    """Classify market regime using SPY moving averages.
+
+    Falls back to a random choice on failure so the rest of the
+    system can continue operating during data issues.
+    """
+    try:
+        spy = yf.download("SPY", period="1y", progress=False)
+        if spy.empty:
+            raise ValueError("No data returned")
+        sma50 = spy["Close"].rolling(50).mean().iloc[-1]
+        sma200 = spy["Close"].rolling(200).mean().iloc[-1]
+        if sma50 > sma200:
+            return "BULL"
+        elif sma50 < sma200:
+            return "BEAR"
+        else:
+            return "CHOPPY"
+    except Exception:
+        return random.choice(REGIMES)
 
 
 def main():
     regime = detect_regime()
+    os.makedirs("../data", exist_ok=True)
     with open("../data/macro_regime.txt", "w") as f:
         f.write(regime)
     print(f"[{datetime.now(timezone.utc)}] 🌎 Market regime -> {regime}")
@@ -18,9 +41,12 @@ def main():
 def current_regime() -> str:
     try:
         with open("../data/macro_regime.txt", "r") as f:
-            return f.read().strip()
+            regime = f.read().strip()
+            if regime:
+                return regime
     except Exception:
-        return "UNKNOWN"
+        pass
+    return detect_regime()
 
 
 if __name__ == "__main__":

--- a/ai_modules/multi_model_ensemble.py
+++ b/ai_modules/multi_model_ensemble.py
@@ -37,7 +37,7 @@ def weighted_ensemble_predict(
     model probabilities are then combined using a small meta learner.
     """
     weights = DEFAULT_WEIGHTS.copy()
-    if regime == "CHOP":
+    if regime == "CHOPPY":
         weights["CNN"] *= 1.5
         weights["CatBoost"] *= 1.2
     elif regime == "BULL":

--- a/predict_core.py
+++ b/predict_core.py
@@ -23,8 +23,11 @@ def predict():
         print(f"[{datetime.now(timezone.utc)}] 🔻 Mean reversion short signal")
     if vote:
         print(f"[{datetime.now(timezone.utc)}] 🧠 Ensemble vote suggests entry; confidence {confidence:.2f}")
+
+    level = "✅ High" if confidence >= 0.9 else "🟡 Medium" if confidence >= 0.7 else "⚠️ Low"
+    print(f"[{datetime.now(timezone.utc)}] {level} confidence {confidence:.2f}")
     if confidence < 0.7:
-        print(f"[{datetime.now(timezone.utc)}] ⚠️ Low confidence {confidence:.2f}. Skipping trade")
+        print(f"[{datetime.now(timezone.utc)}] Skipping trade")
         return
     if avoid_trade:
         print(f"[{datetime.now(timezone.utc)}] 🚩 Negative news detected. Avoiding trades")

--- a/strategy_writer.py
+++ b/strategy_writer.py
@@ -6,6 +6,7 @@ STRATEGY_DIR = "../strategy"
 LOG_FILE = "../logs/self_written.log"
 os.makedirs(STRATEGY_DIR, exist_ok=True)
 os.makedirs("../logs", exist_ok=True)
+os.makedirs("../logs/alpha_strategies", exist_ok=True)
 
 def generate_strategy(name):
     templates = [
@@ -38,6 +39,10 @@ file_name = os.path.join(STRATEGY_DIR, f"{strat_name}.py")
 with open(file_name, "w") as f:
     f.write(generate_strategy(strat_name))
 
+alpha_copy = os.path.join("../logs/alpha_strategies", f"{strat_name}.py")
+with open(alpha_copy, "w") as f:
+    f.write(open(file_name).read())
+
 with open(LOG_FILE, "a") as log:
     log.write(f"[{datetime.now(timezone.utc)}] 🧠 Created new strategy: {strat_name}.py\n")
 
@@ -49,4 +54,7 @@ if __name__ == "__main__":
     file_name = os.path.join("../strategy", f"{strat_name}.py")
     with open(file_name, "w") as f:
         f.write(generate_strategy(strat_name))
+    alpha_copy = os.path.join("../logs/alpha_strategies", f"{strat_name}.py")
+    with open(alpha_copy, "w") as f:
+        f.write(open(file_name).read())
     print(f"✅ New strategy written: {strat_name}.py")

--- a/trade_journal.py
+++ b/trade_journal.py
@@ -1,17 +1,29 @@
 from datetime import datetime, timezone
 import os
+import csv
 
-JOURNAL_PATH = "../logs/trade_journal.md"
-os.makedirs("../logs", exist_ok=True)
+JOURNAL_DIR = "../logs"
+os.makedirs(JOURNAL_DIR, exist_ok=True)
 
-def journal_trade(ticker, reason, pnl, confidence):
-    entry = (
-        f"- {ticker} | PnL: {pnl:+.2f} | Confidence: {confidence:.2f}\n"
-        f"  Reason: {reason}\n"
-    )
-    with open(JOURNAL_PATH, "a") as f:
-        f.write(f"[{datetime.now(timezone.utc)}] \n{entry}\n")
+
+def journal_trade(symbol: str, strategy: str, fill: float, pnl: float, stop: float) -> None:
+    """Append a trade entry to a dated CSV journal."""
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    path = os.path.join(JOURNAL_DIR, f"trade_journal_{date_str}.csv")
+    file_exists = os.path.exists(path)
+    with open(path, "a", newline="") as f:
+        writer = csv.writer(f)
+        if not file_exists:
+            writer.writerow(["time", "symbol", "strategy", "fill", "PnL", "stop"])
+        writer.writerow([
+            datetime.now(timezone.utc).isoformat(),
+            symbol,
+            strategy,
+            fill,
+            pnl,
+            stop,
+        ])
 
 if __name__ == "__main__":
-    journal_trade("TSLA", "Oversold bounce", 50, 0.84)
+    journal_trade("TSLA", "Oversold bounce", 10.5, 50, 8.0)
     print("Journal updated")


### PR DESCRIPTION
## Summary
- implement basic SPY SMA regime detection
- handle CHOPPY regime in ensemble
- log confidence tiers in predictions
- store simulated trades to dated CSV journal
- copy generated strategies to `logs/alpha_strategies`
- document pytest usage and add CI workflow

## Testing
- `pip install pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5e4373f4832185bc85a9f307947d