### PR TITLE
Add options intelligence toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ python -m unittest discover -s tests
 - **Dark Pool & Options Flow** – `ai_modules/dark_pool_flow.py` flags unusual dark pool prints and options activity.
 - **Social Alpha Integration** – `ai_modules/social_alpha.py` scrapes r/WallStreetBets and StockTwits for trending tickers.
 - **Penny-Options Integration** – `penny_options_bot.py` cross-checks penny watchlists with options filters.
+- **Options Intelligence Toolkit** – `flow_scanner.py`, `delta_filter.py`, `smart_roller.py` and more provide scanning, delta selection, IV and POP filters, and ladder building.

--- a/delta_filter.py
+++ b/delta_filter.py
@@ -1,0 +1,2 @@
+def choose_strike(chain, delta_range):
+    return [o for o in chain if delta_range[0] <= o['delta'] <= delta_range[1]]

--- a/earnings_filter.py
+++ b/earnings_filter.py
@@ -1,0 +1,2 @@
+def filter_out_earnings(chain):
+    return [c for c in chain if not c['earnings_this_week']]

--- a/flow_scanner.py
+++ b/flow_scanner.py
@@ -1,0 +1,2 @@
+def scan_unusual(options_data):
+    return [o for o in options_data if o['volume'] > o['oi'] * 2 and o['oi'] > 500]

--- a/greeks_logger.py
+++ b/greeks_logger.py
@@ -1,0 +1,2 @@
+def log_greeks(contract):
+    print(f"{contract['symbol']}: \u0394={contract['delta']} \u0398={contract['theta']} \u0393={contract['gamma']}")

--- a/iv_rank_filter.py
+++ b/iv_rank_filter.py
@@ -1,0 +1,2 @@
+def is_iv_rank_ok(iv_rank, mode):
+    return iv_rank > 50 if mode == 'sell' else iv_rank < 20

--- a/ladder_builder.py
+++ b/ladder_builder.py
@@ -1,0 +1,2 @@
+def build_ladder(symbol, base_strike, count=3):
+    return [f"{symbol}_{base_strike + 5*i}_C" for i in range(count)]

--- a/pop_filter.py
+++ b/pop_filter.py
@@ -1,0 +1,2 @@
+def filter_by_pop(chain, min_pop=0.70):
+    return [c for c in chain if c['pop'] > min_pop]

--- a/premium_decay.py
+++ b/premium_decay.py
@@ -1,0 +1,2 @@
+def track_decay(entry_premium, time_held, current_premium):
+    return (entry_premium - current_premium) / time_held

--- a/short_dte_selector.py
+++ b/short_dte_selector.py
@@ -1,0 +1,2 @@
+def select_short_dte(chain):
+    return [c for c in chain if 6 <= c['dte'] <= 10]

--- a/smart_roller.py
+++ b/smart_roller.py
@@ -1,0 +1,5 @@
+def should_roll(pnl_pct, dte):
+    return pnl_pct >= 0.5 or dte < 2
+
+def roll_contract(symbol):
+    print(f'\U0001F501 Rolling {symbol} for continued premium...')


### PR DESCRIPTION
## Summary
- add flow scanner for detecting unusual options activity
- add delta-based strike selector
- implement smart rolling helper
- filter by IV rank, POP and earnings schedule
- provide greeks logger, premium decay tracker and short DTE selector
- build ladders for options
- document new options toolkit in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e617862c883219551c952dc8d807d