### PR TITLE
Add placeholder modules for upgraded bot

### DIFF
--- a/superbot_ultimate_upgrade/ai_modules/async_scanner.py
+++ b/superbot_ultimate_upgrade/ai_modules/async_scanner.py
@@ -1,0 +1,1 @@
+import aiohttp, asyncio

--- a/superbot_ultimate_upgrade/ai_modules/decision_engine.py
+++ b/superbot_ultimate_upgrade/ai_modules/decision_engine.py
@@ -1,0 +1,1 @@
+# Uses news, tech, pattern, social, vote consensus

--- a/superbot_ultimate_upgrade/ai_modules/regime_switcher.py
+++ b/superbot_ultimate_upgrade/ai_modules/regime_switcher.py
@@ -1,0 +1,1 @@
+# Placeholder for regime_switcher

--- a/superbot_ultimate_upgrade/ai_modules/reward_optimizer.py
+++ b/superbot_ultimate_upgrade/ai_modules/reward_optimizer.py
@@ -1,0 +1,1 @@
+# Placeholder for reward_optimizer

--- a/superbot_ultimate_upgrade/ai_modules/self_trainer.py
+++ b/superbot_ultimate_upgrade/ai_modules/self_trainer.py
@@ -1,0 +1,1 @@
+# Trains a classifier daily using trade journal outcomes

--- a/superbot_ultimate_upgrade/ai_modules/smart_position_size.py
+++ b/superbot_ultimate_upgrade/ai_modules/smart_position_size.py
@@ -1,0 +1,1 @@
+# Placeholder for smart_position_size

--- a/superbot_ultimate_upgrade/ai_modules/trade_cooldown.py
+++ b/superbot_ultimate_upgrade/ai_modules/trade_cooldown.py
@@ -1,0 +1,1 @@
+# Placeholder for trade_cooldown

--- a/superbot_ultimate_upgrade/ai_modules/trade_filter.py
+++ b/superbot_ultimate_upgrade/ai_modules/trade_filter.py
@@ -1,0 +1,1 @@
+# Placeholder for trade_filter

--- a/superbot_ultimate_upgrade/ai_modules/trade_throttle.py
+++ b/superbot_ultimate_upgrade/ai_modules/trade_throttle.py
@@ -1,0 +1,1 @@
+# Placeholder for trade_throttle

--- a/superbot_ultimate_upgrade/backups/auto_backup.py
+++ b/superbot_ultimate_upgrade/backups/auto_backup.py
@@ -1,0 +1,1 @@
+# Placeholder for auto_backup

--- a/superbot_ultimate_upgrade/execution/exit_strategies.py
+++ b/superbot_ultimate_upgrade/execution/exit_strategies.py
@@ -1,0 +1,1 @@
+# Supports ladder exit, trailing ATR, timeouts

--- a/superbot_ultimate_upgrade/logs/equity_curve_plot.py
+++ b/superbot_ultimate_upgrade/logs/equity_curve_plot.py
@@ -1,0 +1,1 @@
+# Placeholder for equity_curve_plot

--- a/superbot_ultimate_upgrade/logs/summary_generator.py
+++ b/superbot_ultimate_upgrade/logs/summary_generator.py
@@ -1,0 +1,1 @@
+# Placeholder for summary_generator

--- a/superbot_ultimate_upgrade/logs/trade_logger.py
+++ b/superbot_ultimate_upgrade/logs/trade_logger.py
@@ -1,0 +1,1 @@
+# Placeholder for trade_logger

--- a/superbot_ultimate_upgrade/main.py
+++ b/superbot_ultimate_upgrade/main.py
@@ -1,0 +1,1 @@
+# Master controller to run scanning, decision, execution, logging

--- a/superbot_ultimate_upgrade/news_sentiment/headline_ai.py
+++ b/superbot_ultimate_upgrade/news_sentiment/headline_ai.py
@@ -1,0 +1,1 @@
+# Classifies headlines into bullish/bearish using OpenAI/NLTK

--- a/superbot_ultimate_upgrade/news_sentiment/social_signal.py
+++ b/superbot_ultimate_upgrade/news_sentiment/social_signal.py
@@ -1,0 +1,1 @@
+# Scrapes Reddit & Twitter tags + spikes

--- a/superbot_ultimate_upgrade/options_strategies/contract_recommender.py
+++ b/superbot_ultimate_upgrade/options_strategies/contract_recommender.py
@@ -1,0 +1,1 @@
+# Placeholder for contract_recommender

--- a/superbot_ultimate_upgrade/options_strategies/delta_filter.py
+++ b/superbot_ultimate_upgrade/options_strategies/delta_filter.py
@@ -1,0 +1,1 @@
+# Placeholder for delta_filter

--- a/superbot_ultimate_upgrade/options_strategies/earnings_filter.py
+++ b/superbot_ultimate_upgrade/options_strategies/earnings_filter.py
@@ -1,0 +1,1 @@
+# Placeholder for earnings_filter

--- a/superbot_ultimate_upgrade/options_strategies/flow_scanner.py
+++ b/superbot_ultimate_upgrade/options_strategies/flow_scanner.py
@@ -1,0 +1,1 @@
+# Placeholder for flow_scanner

--- a/superbot_ultimate_upgrade/options_strategies/greeks_logger.py
+++ b/superbot_ultimate_upgrade/options_strategies/greeks_logger.py
@@ -1,0 +1,1 @@
+# Placeholder for greeks_logger

--- a/superbot_ultimate_upgrade/options_strategies/iv_rank_filter.py
+++ b/superbot_ultimate_upgrade/options_strategies/iv_rank_filter.py
@@ -1,0 +1,1 @@
+# Placeholder for iv_rank_filter

--- a/superbot_ultimate_upgrade/options_strategies/ladder_builder.py
+++ b/superbot_ultimate_upgrade/options_strategies/ladder_builder.py
@@ -1,0 +1,1 @@
+# Placeholder for ladder_builder

--- a/superbot_ultimate_upgrade/options_strategies/pop_selector.py
+++ b/superbot_ultimate_upgrade/options_strategies/pop_selector.py
@@ -1,0 +1,1 @@
+# Placeholder for pop_selector

--- a/superbot_ultimate_upgrade/options_strategies/roll_logic.py
+++ b/superbot_ultimate_upgrade/options_strategies/roll_logic.py
@@ -1,0 +1,1 @@
+def should_roll(pnl_pct, dte): return pnl_pct > 0.5 or dte < 3

--- a/superbot_ultimate_upgrade/options_strategies/spread_generator.py
+++ b/superbot_ultimate_upgrade/options_strategies/spread_generator.py
@@ -1,0 +1,1 @@
+# Placeholder for spread_generator

--- a/superbot_ultimate_upgrade/options_strategies/time_decay_maximizer.py
+++ b/superbot_ultimate_upgrade/options_strategies/time_decay_maximizer.py
@@ -1,0 +1,1 @@
+# Placeholder for time_decay_maximizer

--- a/superbot_ultimate_upgrade/penny_strategies/abnormal_volume.py
+++ b/superbot_ultimate_upgrade/penny_strategies/abnormal_volume.py
@@ -1,0 +1,1 @@
+# Placeholder for abnormal_volume

--- a/superbot_ultimate_upgrade/penny_strategies/float_filter.py
+++ b/superbot_ultimate_upgrade/penny_strategies/float_filter.py
@@ -1,0 +1,1 @@
+# Placeholder for float_filter

--- a/superbot_ultimate_upgrade/penny_strategies/gap_scanner.py
+++ b/superbot_ultimate_upgrade/penny_strategies/gap_scanner.py
@@ -1,0 +1,1 @@
+# Placeholder for gap_scanner

--- a/superbot_ultimate_upgrade/penny_strategies/momentum_timer.py
+++ b/superbot_ultimate_upgrade/penny_strategies/momentum_timer.py
@@ -1,0 +1,1 @@
+# Placeholder for momentum_timer

--- a/superbot_ultimate_upgrade/penny_strategies/news_confirmation.py
+++ b/superbot_ultimate_upgrade/penny_strategies/news_confirmation.py
@@ -1,0 +1,1 @@
+# Placeholder for news_confirmation

--- a/superbot_ultimate_upgrade/penny_strategies/pump_detector.py
+++ b/superbot_ultimate_upgrade/penny_strategies/pump_detector.py
@@ -1,0 +1,1 @@
+# Placeholder for pump_detector

--- a/superbot_ultimate_upgrade/penny_strategies/range_breakout.py
+++ b/superbot_ultimate_upgrade/penny_strategies/range_breakout.py
@@ -1,0 +1,1 @@
+# Placeholder for range_breakout

--- a/superbot_ultimate_upgrade/penny_strategies/reddit_hype.py
+++ b/superbot_ultimate_upgrade/penny_strategies/reddit_hype.py
@@ -1,0 +1,1 @@
+# Placeholder for reddit_hype

--- a/superbot_ultimate_upgrade/penny_strategies/timeofday_filter.py
+++ b/superbot_ultimate_upgrade/penny_strategies/timeofday_filter.py
@@ -1,0 +1,1 @@
+# Placeholder for timeofday_filter

--- a/superbot_ultimate_upgrade/penny_strategies/vote_filter.py
+++ b/superbot_ultimate_upgrade/penny_strategies/vote_filter.py
@@ -1,0 +1,1 @@
+def vote(models): return sum(models) >= 3

--- a/superbot_ultimate_upgrade/penny_strategies/vwap_reclaim.py
+++ b/superbot_ultimate_upgrade/penny_strategies/vwap_reclaim.py
@@ -1,0 +1,1 @@
+# Placeholder for vwap_reclaim


### PR DESCRIPTION
## Summary
- create `superbot_ultimate_upgrade` with folders for AI modules, strategies and logs
- add placeholder modules including async scanner, decision engine, roll logic, vote filter, and more
- include a skeleton main runner

## Testing
- `pip install yfinance pandas scikit-learn aiohttp nest_asyncio matplotlib nltk beautifulsoup4 openai stable-baselines3 python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e62d7411483219100b52fee96d623