### PR TITLE
Add equity curve watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ pytest tests/
 - **Social Alpha Integration** – `ai_modules/social_alpha.py` scrapes r/WallStreetBets and StockTwits for trending tickers.
 - **Penny-Options Integration** – `penny_options_bot.py` cross-checks penny watchlists with options filters.
 - **Options Intelligence Toolkit** – `flow_scanner.py`, `delta_filter.py`, `smart_roller.py` and more provide scanning, delta selection, IV and POP filters, and ladder building.
+
+- **Equity Curve Watchdog** – `equity_curve_watchdog.py` pauses trading if the drawdown exceeds a configurable threshold.

--- a/equity_curve_watchdog.py
+++ b/equity_curve_watchdog.py
@@ -1,0 +1,14 @@
+"""
+Watches equity curve performance and triggers pause signals if drawdown exceeds threshold.
+"""
+
+def monitor_equity_curve(equity_history, max_drawdown_pct=0.15):
+    if not equity_history:
+        return False
+    peak = max(equity_history)
+    current = equity_history[-1]
+    drawdown = (peak - current) / peak
+    if drawdown > max_drawdown_pct:
+        print(f"⚠️ Drawdown alert: {drawdown:.2%} exceeded max of {max_drawdown_pct:.2%}")
+        return True
+    return False

--- a/tests/test_equity_curve_watchdog.py
+++ b/tests/test_equity_curve_watchdog.py
@@ -1,0 +1,15 @@
+import unittest
+
+import equity_curve_watchdog
+
+class EquityCurveWatchdogTestCase(unittest.TestCase):
+    def test_alert_triggered(self):
+        history = [100, 120, 110, 80]
+        self.assertTrue(equity_curve_watchdog.monitor_equity_curve(history, 0.2))
+
+    def test_no_alert(self):
+        history = [100, 105, 103]
+        self.assertFalse(equity_curve_watchdog.monitor_equity_curve(history, 0.2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `equity_curve_watchdog.py` to monitor drawdowns
- document new watchdog tool in the README
- add unit tests for the equity curve watchdog

## Testing
- `pip install -q -r requirements.txt` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e9b2d1f8c8321ae38313172458c68