### PR TITLE
Add trade preview screen

### DIFF
--- a/trade_preview_screen.py
+++ b/trade_preview_screen.py
@@ -1,0 +1,9 @@
+"""
+Displays pre-trade candidates and their estimated win rate for review.
+"""
+
+def preview_trades(trade_candidates):
+    """Prints the top three trade candidates sorted by confidence."""
+    print("\U0001F4CB Trade Preview:")
+    for i, trade in enumerate(sorted(trade_candidates, key=lambda t: t.get('confidence', 0), reverse=True)[:3]):
+        print(f"{i+1}. {trade['symbol']} | Win chance: {trade['confidence']:.1%} | Reason: {trade['reason']}")


### PR DESCRIPTION
## Summary
- implement `trade_preview_screen.py` for reviewing potential trades sorted by win rate

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9b53571483219bc346486dd37af9