### PR TITLE
Add trading utility modules

### DIFF
--- a/adaptive_trade_filter.py
+++ b/adaptive_trade_filter.py
@@ -1,0 +1,8 @@
+"""
+Filters trades based on adaptive criteria like volatility, market regime, and AI predictions.
+"""
+
+
+def filter_trades(trades, market_volatility):
+    threshold = 0.6 if market_volatility > 0.3 else 0.4
+    return [t for t in trades if t['ai_score'] > threshold]

--- a/ai_trade_throttle.py
+++ b/ai_trade_throttle.py
@@ -1,0 +1,10 @@
+"""
+Limits trade frequency during high volatility or when win rate drops to preserve capital.
+"""
+
+
+def throttle_decision(win_rate, trade_count, max_trades=10):
+    if win_rate < 0.7 or trade_count >= max_trades:
+        print("\ud83d\udded Throttle triggered: Waiting for better setup.")
+        return True
+    return False

--- a/options_strategy_optimizer.py
+++ b/options_strategy_optimizer.py
@@ -1,0 +1,9 @@
+"""
+AI-powered options optimizer that selects contracts with highest reward/risk ratio and 90%+ win probability.
+"""
+
+
+def find_best_options_trade(candidates):
+    high_prob = [c for c in candidates if c.get('win_rate', 0) > 0.9 and c.get('reward_risk', 0) > 1.5]
+    best = sorted(high_prob, key=lambda x: x['reward_risk'], reverse=True)
+    return best[:3]

--- a/penny_stock_momentum_ai.py
+++ b/penny_stock_momentum_ai.py
@@ -1,0 +1,11 @@
+"""
+Detects penny stocks with momentum based on volume spikes, price action, and trend models.
+"""
+
+
+def detect_momentum_stocks(stock_data):
+    result = []
+    for stock in stock_data:
+        if stock['price'] < 5 and stock['volume'] > stock['avg_volume'] * 3 and stock['trend'] > 0:
+            result.append(stock)
+    return sorted(result, key=lambda x: x['trend'], reverse=True)

--- a/rapid_ticker_scanner.py
+++ b/rapid_ticker_scanner.py
@@ -1,0 +1,8 @@
+"""
+Scans hundreds of tickers per second with lightweight filters before deeper analysis.
+"""
+
+
+def rapid_scan(tickers):
+    print(f"\u26a1 Rapid scanning {len(tickers)} tickers...")
+    return [t for t in tickers if len(t) < 6 and not any(x in t for x in ["$", "-"])]


### PR DESCRIPTION
## Summary
- add optimizer that picks option contracts with strong risk/reward
- detect momentum in penny stocks
- throttle trades when win rate is low
- scan tickers quickly with lightweight filter
- filter trades using an adaptive AI score

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9d811e7c8321a4724c1b7391d08f