### PR TITLE
Add Streamlit dashboard support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,10 @@ FROM python:3.10
 WORKDIR /app
 COPY . /app
 RUN pip install -r requirements.txt
+# Install streamlit
+RUN pip install streamlit
 
-CMD ["python3", "main.py"]
+# Expose Streamlit port
+EXPOSE 8501
+
+CMD ["streamlit", "run", "/app/gui.py", "--server.enableCORS", "false"]

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ pytest tests/
 - **GUI Control Panel** – `superbot_gui.py` offers a Tkinter interface for managing credentials and viewing mock trade ideas.
 - **Streamlit Dashboard** – `gui.py` runs in the browser for viewing predictions and trade logs.
 - **Equity Curve Watchdog** – `equity_curve_watchdog.py` pauses trading if the drawdown exceeds a configurable threshold.
+
+## Running the Web Dashboard in Docker
+
+Build the Docker image and start the Streamlit dashboard:
+
+```bash
+docker build -t superbot-auto:latest .
+docker run -it --rm -p 8501:8501 superbot-auto:latest
+```
+
+Then open <http://localhost:8501> in your browser to view the dashboard.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ stable-baselines3
 scikit-learn
 beautifulsoup4
 openai
+streamlit


### PR DESCRIPTION
## Summary
- install Streamlit via requirements
- update Dockerfile to run Streamlit dashboard by default
- document how to launch the web UI in Docker

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb4d7ef2c8321b8e01f5c62bb495d