### PR TITLE
Add RL learner and strategy utilities

### DIFF
--- a/greeks_monitor.py
+++ b/greeks_monitor.py
@@ -1,0 +1,13 @@
+import random
+
+
+def get_greeks(symbol: str):
+    """Return option greeks for the given symbol. Placeholder for IBKR API."""
+    greeks = {
+        "delta": round(random.uniform(-1, 1), 2),
+        "gamma": round(random.uniform(0, 1), 2),
+        "theta": round(random.uniform(-1, 0), 2),
+        "vega": round(random.uniform(0, 1), 2),
+    }
+    print(f"[GREEKS] {symbol}: {greeks}")
+    return greeks

--- a/reinforcement_learner.py
+++ b/reinforcement_learner.py
@@ -1,0 +1,43 @@
+import pickle
+import os
+import random
+
+Q_FILE = "q_table.pkl"
+
+class ReinforcementLearner:
+    """Simple reinforcement learning framework using a Q-table."""
+
+    def __init__(self):
+        self.q_table = self.load_q_table()
+        self.pnl_history = {}
+
+    def load_q_table(self):
+        if os.path.exists(Q_FILE):
+            try:
+                with open(Q_FILE, "rb") as f:
+                    return pickle.load(f)
+            except Exception:
+                return {}
+        return {}
+
+    def save_q_table(self):
+        with open(Q_FILE, "wb") as f:
+            pickle.dump(self.q_table, f)
+
+    def update(self, strategy_name: str, pnl: float):
+        """Update Q value for a strategy based on profit/loss."""
+        self.pnl_history.setdefault(strategy_name, []).append(pnl)
+        reward = pnl
+        self.q_table[strategy_name] = self.q_table.get(strategy_name, 0.0) + reward
+        self.save_q_table()
+
+    def recommend(self):
+        """Return a strategy weighted by learned Q values."""
+        if not self.q_table:
+            return None
+        strategies, values = zip(*self.q_table.items())
+        total = sum(max(v, 0.0) for v in values)
+        if total <= 0:
+            return random.choice(strategies)
+        weights = [max(v, 0.0) / total for v in values]
+        return random.choices(strategies, weights=weights, k=1)[0]

--- a/smart_position_sizer.py
+++ b/smart_position_sizer.py
@@ -5,3 +5,11 @@ Dynamically sizes position based on signal quality score and available capital.
 def size_position(capital, signal_strength, base_risk=0.01):
     multiplier = min(max(signal_strength, 0.5), 2.0)
     return round(capital * base_risk * multiplier, 2)
+
+
+def position_size(confidence, volatility, equity=10000, max_risk=0.02):
+    """Return position size based on confidence and volatility."""
+    risk_per_trade = equity * max_risk
+    weight = confidence / (volatility + 1e-6)
+    size = int(risk_per_trade * weight)
+    return max(1, size)

--- a/strategy_mutator.py
+++ b/strategy_mutator.py
@@ -1,0 +1,27 @@
+import os
+import time
+import re
+
+STRATEGY_DIR = "./strategies"
+
+
+def mutate_strategy(file_path: str) -> str:
+    """Create a mutated copy of the strategy file."""
+    with open(file_path, "r") as f:
+        code = f.read()
+
+    # Very naive parameter tweak: increase threshold by 10%
+    code = re.sub(r"threshold\s*=\s*(\d+\.?\d*)", lambda m: f"threshold = {float(m.group(1)) * 1.1:.2f}", code)
+
+    new_filename = f"{STRATEGY_DIR}/alpha_{int(time.time())}.py"
+    with open(new_filename, "w") as f:
+        f.write(code)
+
+    print(f"✅ Mutated strategy saved as {new_filename}")
+    return new_filename
+
+
+def mutate_all():
+    for fname in os.listdir(STRATEGY_DIR):
+        if fname.startswith("alpha_") and fname.endswith(".py"):
+            mutate_strategy(os.path.join(STRATEGY_DIR, fname))

--- a/walk_forward_optimizer.py
+++ b/walk_forward_optimizer.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pandas as pd
+
+
+def evaluate_strategy(df: pd.DataFrame, strategy_func, train_size: int = 100, test_size: int = 20):
+    """Run walk-forward validation using rolling windows."""
+    results = []
+
+    for start in range(0, len(df) - train_size - test_size, test_size):
+        train = df.iloc[start : start + train_size]
+        test = df.iloc[start + train_size : start + train_size + test_size]
+
+        model = strategy_func(train)
+        predictions = model.predict(test)
+
+        pnl = predictions["PnL"]
+        sharpe = pnl.mean() / (pnl.std() or 1)
+        accuracy = (pnl > 0).mean()
+
+        results.append({"start": start, "accuracy": accuracy, "sharpe": sharpe})
+
+    summary = pd.DataFrame(results)
+    print(summary)
+    return summary


### PR DESCRIPTION
## Summary
- implement reinforcement learner with Q-table persistence
- add walk forward strategy optimizer
- add strategy mutation helper
- enhance smart position sizing logic
- add simple options Greeks monitor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb5757a94832193df99c4261dc977