### PR TITLE
Add async scanner and supporting modules

### DIFF
--- a/failover_data_fetcher.py
+++ b/failover_data_fetcher.py
@@ -1,0 +1,29 @@
+"""Fetch ticker data with automatic fallback on failure."""
+
+import os
+
+import pandas as pd
+import yfinance as yf
+
+
+def fetch_data(ticker: str):
+    """Return recent data for ``ticker`` with failover to CSV."""
+    try:
+        df = yf.download(ticker, "5d", "1m", progress=False)
+        if df.empty:
+            raise ValueError("Empty from yfinance")
+        print(f"✅ {ticker} loaded from yfinance")
+        return df
+    except Exception as exc:
+        print(f"⚠️ yfinance failed: {exc}")
+        alt_path = f"backup_data/{ticker}.csv"
+        if os.path.exists(alt_path):
+            df = pd.read_csv(alt_path)
+            print(f"📂 {ticker} loaded from fallback CSV")
+            return df
+        print(f"❌ No data available for {ticker}")
+        return None
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage
+    fetch_data("AAPL")

--- a/news_sentiment_ai.py
+++ b/news_sentiment_ai.py
@@ -1,0 +1,25 @@
+"""Simple news sentiment scoring for tickers."""
+
+from textblob import TextBlob
+
+
+def get_headlines(ticker: str):
+    """Return placeholder list of headlines for ``ticker``."""
+    return [
+        f"{ticker} launches new product line",
+        f"{ticker} stock dips amid broader tech selloff",
+        f"Analysts upgrade {ticker} price target",
+    ]
+
+
+def analyze_sentiment(ticker: str) -> float:
+    """Compute average sentiment score for ``ticker`` headlines."""
+    headlines = get_headlines(ticker)
+    scores = [TextBlob(h).sentiment.polarity for h in headlines]
+    avg_score = sum(scores) / len(scores)
+    print(f"[SENTIMENT] {ticker}: {avg_score:.2f}")
+    return avg_score
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage
+    analyze_sentiment("AAPL")

--- a/self_trainer.py
+++ b/self_trainer.py
@@ -1,0 +1,31 @@
+"""Retrain models daily based on trade history."""
+
+from pathlib import Path
+import pickle
+
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+
+
+def retrain_model(trade_log_path: str) -> None:
+    """Load trade logs and update models per ticker."""
+    df = pd.read_csv(trade_log_path)
+    model_dir = Path("models")
+    model_dir.mkdir(exist_ok=True)
+
+    for ticker in df["Ticker"].unique():
+        sub = df[df["Ticker"] == ticker]
+        X = sub[["Confidence", "Volume", "Volatility"]]
+        y = sub["Success"]
+
+        model = RandomForestClassifier(n_estimators=50)
+        model.fit(X, y)
+
+        with open(model_dir / f"{ticker}_model.pkl", "wb") as f:
+            pickle.dump(model, f)
+
+        print(f"✅ Retrained model for {ticker}")
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage
+    retrain_model("trade_log.csv")

--- a/strategy_kill_switch.py
+++ b/strategy_kill_switch.py
@@ -1,0 +1,23 @@
+"""Disable poorly performing strategies based on recent results."""
+
+from pathlib import Path
+
+import pandas as pd
+
+DISABLED_FILE = "disabled_strategies.txt"
+
+
+def check_kill_switch(log_path: str) -> None:
+    """Disable strategies with low win rate or negative average PnL."""
+    df = pd.read_csv(log_path)
+    strategies = df["Strategy"].unique()
+    out_path = Path(DISABLED_FILE)
+
+    with out_path.open("w") as f:
+        for strategy in strategies:
+            recent = df[df["Strategy"] == strategy].tail(10)
+            win_rate = (recent["PnL"] > 0).mean()
+            avg_pnl = recent["PnL"].mean()
+            if win_rate < 0.4 or avg_pnl < 0:
+                f.write(f"{strategy}\n")
+                print(f"\u26a0\ufe0f Strategy {strategy} disabled")


### PR DESCRIPTION
## Summary
- revamp `async_scanner` to fetch quotes concurrently via `yfinance`
- add `self_trainer` to retrain models from trade logs
- add `strategy_kill_switch` to disable poorly performing strategies
- add sentiment analysis utility `news_sentiment_ai`
- add `failover_data_fetcher` with fallback CSV logic

## Testing
- `pip install -r requirements.txt` *(fails: huge downloads blocked)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686eb5ceeecc8321a9f2fe82fc7789dd