### PR TITLE
Add trade annotator and live GUI metrics

### DIFF
--- a/gui_control.py
+++ b/gui_control.py
@@ -1,0 +1,42 @@
+import streamlit as st
+import pandas as pd
+import matplotlib.pyplot as plt
+import yfinance as yf
+
+from sector_ai import get_sector_analysis
+
+st.set_page_config(page_title="Superbot Control Center", layout="wide")
+
+st.title("\U0001F6E0\ufe0f Superbot Control Center")
+
+st.subheader("\U0001F4C9 Real-Time Price Feed")
+ticker_live = st.text_input("Enter ticker for live price:")
+if st.button("Get Live Price"):
+    try:
+        data = yf.Ticker(ticker_live)
+        hist = data.history(period="1d", interval="1m")
+        current = hist["Close"].iloc[-1]
+        pct_5min = (current - hist["Close"].iloc[-6]) / hist["Close"].iloc[-6] * 100
+        pct_15min = (current - hist["Close"].iloc[-16]) / hist["Close"].iloc[-16] * 100
+        st.metric("Current Price", f"${current:.2f}")
+        st.metric("5 min %", f"{pct_5min:.2f}%")
+        st.metric("15 min %", f"{pct_15min:.2f}%")
+    except Exception as e:
+        st.error(f"Failed to fetch price: {e}")
+
+st.subheader("\U0001F4CA Sector Allocation Overview")
+sector_data = get_sector_analysis()
+df_sectors = pd.DataFrame(sector_data)
+st.dataframe(df_sectors, use_container_width=True)
+
+st.subheader("\U0001F4F0 Sector News Sentiment")
+fig, ax = plt.subplots()
+plt.bar(df_sectors["Sector"], df_sectors["News Score"], color="green")
+st.pyplot(fig)
+
+st.subheader("\U0001F9E0 Trade Reason Log")
+try:
+    ann = pd.read_csv("logs/annotation_log.csv", names=["Time", "Ticker", "Strategy", "Conf", "Reason"])
+    st.dataframe(ann.tail(10), use_container_width=True)
+except Exception:
+    st.warning("No annotations found yet.")

--- a/sector_ai.py
+++ b/sector_ai.py
@@ -1,0 +1,21 @@
+import random
+
+SECTORS = ["Tech", "Energy", "Healthcare", "Financials", "Consumer", "Industrials"]
+
+
+def get_sector_analysis():
+    """Return sector allocation metrics with a suggested decision."""
+    results = []
+    for sector in SECTORS:
+        confidence = round(random.uniform(0.3, 0.9), 2)
+        win_rate = round(random.uniform(0.4, 0.8), 2)
+        news_score = round(random.uniform(-1, 1), 2)
+        decision = "OVERWEIGHT" if confidence > 0.65 and news_score > 0 else "NEUTRAL"
+        results.append({
+            "Sector": sector,
+            "Confidence": confidence,
+            "Win Rate": win_rate,
+            "News Score": news_score,
+            "Decision": decision,
+        })
+    return results

--- a/trade_annotator.py
+++ b/trade_annotator.py
@@ -1,0 +1,25 @@
+import csv
+import datetime
+import os
+
+
+def annotate_trade(ticker, strategy, confidence, signals):
+    """Annotate why a trade was selected and log the explanation."""
+    reasons = []
+    if confidence > 0.7:
+        reasons.append("High multi-agent confidence")
+    if "oversold" in signals:
+        reasons.append("RSI indicates oversold condition")
+    if "news_positive" in signals:
+        reasons.append("Recent news sentiment is positive")
+    if "iv_high" in signals:
+        reasons.append("Implied volatility favorable for premium selling")
+
+    explanation = f"{strategy} triggered due to: " + ", ".join(reasons)
+    print(f"[ANNOTATOR] {ticker} → {explanation}")
+
+    os.makedirs("logs", exist_ok=True)
+    with open("logs/annotation_log.csv", "a", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([datetime.datetime.now().isoformat(), ticker, strategy, confidence, explanation])
+    return explanation


### PR DESCRIPTION
## Summary
- create `trade_annotator.py` for logging annotated reasons
- add `sector_ai.py` with random sector allocation logic
- implement new `gui_control.py` Streamlit dashboard including live price feed, sector breakdown and annotation log view

## Testing
- `pip install pandas yfinance matplotlib schedule python-dotenv requests streamlit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb90e57dc8321815d6f326b04f317