### PR TITLE
Add new auditing and portfolio modules

### DIFF
--- a/adaptive_retrainer.py
+++ b/adaptive_retrainer.py
@@ -1,0 +1,21 @@
+"""Automatically retrain models if recent performance drops."""
+import pandas as pd
+
+from self_trainer import retrain_model
+
+
+def scan_and_retrain() -> None:
+    """Trigger retraining for strategies with low win rate."""
+    df = pd.read_csv("logs/trade_log.csv")
+    strategies = df["Strategy"].unique()
+
+    for strat in strategies:
+        sub = df[df["Strategy"] == strat].tail(20)
+        win_rate = (sub["PnL"] > 0).mean()
+        if win_rate < 0.4:
+            print(f"[RETRAIN] Strategy {strat} under 40% → retraining model...")
+            retrain_model("logs/trade_log.csv")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    scan_and_retrain()

--- a/gui_control.py
+++ b/gui_control.py
@@ -48,3 +48,32 @@ if st.button("Check Compliance"):
         st.error("❌ Trade Blocked")
     else:
         st.success("✅ Trade Allowed")
+
+st.subheader("\ud83d\udcda Strategy Audit")
+if st.button("Audit Strategies"):
+    import strategy_auditor
+    strategy_auditor.audit_strategies()
+    st.success("\u2705 Strategy version log updated.")
+
+st.subheader("\ud83d\udcc8 Portfolio Visualizer")
+if st.button("Show Portfolio"):
+    from portfolio_visualizer import visualize_portfolio
+    fig, pnl = visualize_portfolio()
+    st.pyplot(fig)
+    st.metric("Unrealized PnL", f"${pnl:.2f}")
+
+st.subheader("\ud83e\udde6 Run Interactive Backtest")
+ticker_bt = st.text_input("Ticker")
+strat_bt = st.text_input("Strategy (e.g., alpha_1699889932)")
+start_bt = st.date_input("Start")
+end_bt = st.date_input("End")
+if st.button("Run Backtest"):
+    from interactive_backtester import run_backtest
+    result = run_backtest(ticker_bt, strat_bt, str(start_bt), str(end_bt))
+    st.write(result)
+
+st.subheader("\ud83d\udd01 Auto-Retrain Trigger")
+if st.button("Run Adaptive Retrainer"):
+    from adaptive_retrainer import scan_and_retrain
+    scan_and_retrain()
+    st.success("\u2705 Retraining triggered if needed.")

--- a/interactive_backtester.py
+++ b/interactive_backtester.py
@@ -1,0 +1,38 @@
+"""Quick backtesting utility via Streamlit."""
+import importlib
+
+import pandas as pd
+import yfinance as yf
+
+
+def run_backtest(ticker: str, strategy_name: str, start: str, end: str):
+    """Backtest a strategy on a ticker and return simple metrics."""
+    strat = importlib.import_module(f"strategies.{strategy_name}")
+    df = yf.download(ticker, start=start, end=end, progress=False)
+    df["Signal"] = df["Close"].rolling(5).mean() > df["Close"]
+
+    trades = []
+    for i in range(5, len(df)):
+        if hasattr(strat, "run") and strat.run(df.iloc[:i]) == "BUY":
+            trades.append(df["Close"].iloc[i])
+
+    win_rate = (
+        sum(1 for t in trades if t < df["Close"].iloc[-1]) / len(trades)
+        if trades
+        else 0
+    )
+    pnl = sum(df["Close"].iloc[-1] - t for t in trades)
+    drawdown = (
+        min(
+            df["Close"].iloc[i] - min(df["Close"].iloc[i : i + 5])
+            for i in range(len(df) - 5)
+        )
+        if len(df) >= 5
+        else 0
+    )
+
+    return {"wins": win_rate, "pnl": pnl, "drawdown": drawdown}
+
+
+if __name__ == "__main__":  # pragma: no cover - simple usage example
+    print(run_backtest("SPY", "alpha_dummy", "2020-01-01", "2020-06-01"))

--- a/portfolio_visualizer.py
+++ b/portfolio_visualizer.py
@@ -1,0 +1,23 @@
+"""Visualize open positions and PnL."""
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def visualize_portfolio():
+    """Plot portfolio exposure by sector and compute unrealized PnL."""
+    df = pd.read_csv("logs/positions.csv")
+    sector_exposure = df.groupby("Sector")["Value"].sum()
+    pnl = df["UnrealizedPnL"].sum()
+
+    print(f"[PORTFOLIO] Net PnL: ${pnl:.2f}")
+
+    fig, ax = plt.subplots()
+    sector_exposure.plot(kind="barh", color="skyblue", ax=ax)
+    ax.set_title("Sector Exposure")
+    ax.set_xlabel("Value")
+    plt.tight_layout()
+    return fig, pnl
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    visualize_portfolio()

--- a/strategy_auditor.py
+++ b/strategy_auditor.py
@@ -1,0 +1,37 @@
+"""Track strategy versions and hashes."""
+import csv
+import hashlib
+import os
+import time
+
+
+def hash_file(path: str) -> str:
+    """Return md5 hash of file contents."""
+    with open(path, "rb") as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+
+def audit_strategies() -> None:
+    """Log hashes of all alpha strategy files."""
+    log_path = "logs/strategy_audit_log.csv"
+    seen = set()
+
+    if os.path.exists(log_path):
+        with open(log_path) as f:
+            for line in f:
+                seen.add(line.split(",")[0])
+
+    os.makedirs("logs", exist_ok=True)
+    with open(log_path, "a", newline="") as f:
+        writer = csv.writer(f)
+        for file in os.listdir("strategies"):
+            if file.startswith("alpha_") and file.endswith(".py"):
+                path = f"strategies/{file}"
+                sig = hash_file(path)
+                if sig not in seen:
+                    writer.writerow([sig, file, int(time.time())])
+                    print(f"[AUDIT] Logged new strategy version: {file}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual trigger
+    audit_strategies()


### PR DESCRIPTION
## Summary
- implement `strategy_auditor` for hashing and logging strategy versions
- implement `portfolio_visualizer` for sector exposure plots and PnL
- implement `interactive_backtester` for quick strategy tests
- implement `adaptive_retrainer` for automatic model retraining
- extend `gui_control` with buttons to access new utilities

## Testing
- `pip install -q pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eba42bdc48321a92d4bf46f078e02