### PR TITLE
Expand ticker scan capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pytest tests/
 - **GUI Control Panel** – `superbot_gui.py` offers a Tkinter interface for managing credentials and viewing mock trade ideas.
 - **Streamlit Dashboard** – `gui.py` runs in the browser for viewing predictions and trade logs.
 - **Equity Curve Watchdog** – `equity_curve_watchdog.py` pauses trading if the drawdown exceeds a configurable threshold.
+- **Expanded Ticker Scanning** – `learn_core.py` stores results in `data/full_scan_results.csv` and scans up to 5000 tickers.
 
 ## Running the Web Dashboard in Docker
 

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
-MAX_SCAN_TICKERS = 100
+# Maximum number of tickers to scan during the learning phase.
+# Increased from 100 to allow scanning of nearly the entire market.
+MAX_SCAN_TICKERS = 5000
 EMAIL_REPORT_INTERVAL_HOURS = 3
 DAILY_SUMMARY_HOUR_UTC = 23

--- a/learn_core.py
+++ b/learn_core.py
@@ -23,6 +23,11 @@ MACRO_SYMBOLS = {
 MODEL_DIR = "../models"
 os.makedirs(MODEL_DIR, exist_ok=True)
 
+# Persist full scan results for analysis. This path points to a CSV database
+# that grows much larger than the previous `scan_results.csv` file.
+SCAN_RESULTS_FILE = "../data/full_scan_results.csv"
+os.makedirs(os.path.dirname(SCAN_RESULTS_FILE), exist_ok=True)
+
 # Limit the number of tickers scanned to avoid extremely long runtimes.
 # Uses the value configured in config.py
 MAX_TICKERS = config.MAX_SCAN_TICKERS
@@ -247,8 +252,9 @@ if __name__ == "__main__":
 
     print("✅ Scan complete.")
 
-    # Write scan results for debugging
-    with open("scan_results.csv", "w") as f:
+    # Write scan results for debugging. Store them in ``SCAN_RESULTS_FILE``
+    # so we keep a larger persistent database of scan data.
+    with open(SCAN_RESULTS_FILE, "w") as f:
         writer = csv.writer(f)
         writer.writerow(["Ticker", "Last Close"])
         for t, p in features.items():


### PR DESCRIPTION
## Summary
- increase MAX_SCAN_TICKERS to 5000
- store learn_core scan results in `data/full_scan_results.csv`
- document expanded scanning capability in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec52b5c4c8321ad65e378109e90e8